### PR TITLE
Switch README to point to conda-forge package of robometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Robometry
 
 ![Continuous Integration](https://github.com/robotology/robometry/workflows/Continuous%20Integration/badge.svg)
 
-[![Anaconda-Server Badge](https://anaconda.org/robotology/robometry/badges/downloads.svg)](https://anaconda.org/robotology/robometry)
-[![Anaconda-Server Badge](https://anaconda.org/robotology/robometry/badges/installer/conda.svg)](https://conda.anaconda.org/robotology)
-[![Anaconda-Server Badge](https://anaconda.org/robotology/robometry/badges/platforms.svg)](https://anaconda.org/robotology/robometry)
+[![Anaconda-Server Badge](https://anaconda.org/robotology/robometry/badges/downloads.svg)](https://anaconda.org/conda-forge/librobometry)
+[![Anaconda-Server Badge](https://anaconda.org/robotology/robometry/badges/installer/conda.svg)](https://anaconda.org/conda-forge/librobometry)
+[![Anaconda-Server Badge](https://anaconda.org/robotology/robometry/badges/platforms.svg)](https://anaconda.org/conda-forge/librobometry)
 
 Telemetry suite for logging data from your robot 🤖.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Telemetry suite for logging data from your robot 🤖.
 
 ### Conda packages
 
-It is possible to install on `linux`, `macOS` and `Windows` via [conda](https://anaconda.org/conda-forge/robometry), just running:
+It is possible to install on `linux`, `macOS` and `Windows` via [conda](https://anaconda.org/conda-forge/librobometry), just running:
 ```bash
 conda install -c conda-forge librobometry
 ```

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Telemetry suite for logging data from your robot 🤖.
 
 ### Conda packages
 
-It is possible to install on `linux`, `macOS` and `Windows` via [conda](https://anaconda.org/robotology/robometry), just running:
+It is possible to install on `linux`, `macOS` and `Windows` via [conda](https://anaconda.org/conda-forge/robometry), just running:
 ```bash
-conda install -c robotology robometry
+conda install -c conda-forge librobometry
 ```
 
 ## Installation from sources


### PR DESCRIPTION
After https://github.com/conda-forge/staged-recipes/pull/20219, robometry is officially available on conda-forge without the need to use the additional robotology channel.