### PR TITLE
TelemetryDeviceDumper: add log_period parameter

### DIFF
--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -14,7 +14,7 @@ using namespace robometry;
 using namespace yarp::os;
 using namespace yarp::dev;
 
-constexpr double period_thread{ 0.010 };
+constexpr double log_thread_default{ 0.010 };
 
 
 void convertVectorFromDegreesToRadians(std::vector<double>& inVec) {
@@ -58,7 +58,7 @@ bool getUsedDOFsList(yarp::os::Searchable& config, std::vector<std::string>& use
 }
 
 // For now also the period is harcoded, it can be configured
-TelemetryDeviceDumper::TelemetryDeviceDumper() : yarp::os::PeriodicThread(period_thread) {
+TelemetryDeviceDumper::TelemetryDeviceDumper() : yarp::os::PeriodicThread(log_thread_default) {
     // TODO
 }
 
@@ -183,6 +183,10 @@ bool TelemetryDeviceDumper::loadSettingsFromConfig(yarp::os::Searchable& config)
                 m_bufferConfig.data_threshold = prop.find(data_threshold.c_str()).asInt32();
             }
 
+        }
+
+        if (prop.check("log_period") && prop.find("log_period").isFloat64()) {
+            this->setPeriod(prop.find("log_period").asFloat64());
         }
 
         std::string auto_save = "auto_save";

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -76,6 +76,7 @@ struct TelemetryDeviceDumperSettings {
  * | `n_samples`     | size_t     | -     | -     | Yes     | The max number of samples contained in the circular buffer/s     |
  * | `save_periodically`     | bool     | -     | false     | No(but it has to be set to true if `auto_save` is set to false)     | The flag for enabling the periodic save thread.     |
  * | `save_period`     | double     | seconds     | -     | Yes(if `save_periodically` is set to true)     | The period in seconds of the save thread     |
+ * | `log_period`     | double     | seconds     | 0.010    | No    | The period in seconds of the logging thread.     |
  * | `data_threshold`     | size_t     | -     | 0     | No     | The save thread saves to a file if there are at least `data_threshold` samples     |
  * | `auto_save`     | bool     | -     | false     | No(but it has to be set to true if `save_periodically` is set to false)     | the flag for enabling the save in the destructor of the `robometry::BufferManager`     |
  * | `yarp_robot_name`     | string     | -     | ""     | No     | Name of the robot used during the experiment.     |


### PR DESCRIPTION
Before it used only 10 ms as default.


cc @marcoaccame @simeonedussoni