### PR TITLE
Add to TelemetryDeviceDumper streaming of rawValues from low level

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ The configuration can be saved **to a json file**
 
 ## TelemetryDeviceDumper
 
-The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_devices.html) that has to be launched through the [`yarprobotinterface`](http://yarp.it/git-master/yarprobotinterface.html) for dumping quantities from your robot(e.g. encoders, velocities etc.) in base of what specified in the configuration.
+The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_devices.html) that has to be launched through the [`yarprobotinterface`](http://yarp.it/git-master/yarprobotinterface.html) for dumping quantities from your robot(e.g. encoders, velocities etc.) in base of what specified in the configuration. It currently needs icub-main version equal or higher than `2.7.0` Specificially this is needed when enabling the parameter `logIRawValuesPublisher`, which is used for dumping any type of raw data values coming from the low level, e.g. raw encoder data. 
 
 ### Export the env variables
 * Add `${CMAKE_INSTALL_PREFIX}/share/yarp` (where `${CMAKE_INSTALL_PREFIX}` needs to be substituted to the directory that you choose as the `CMAKE_INSTALL_PREFIX`) to your `YARP_DATA_DIRS` environment variable (for more on the `YARP_DATA_DIRS` env variable, see [YARP documentation on data directories](http://www.yarp.it/yarp_data_dirs.html) ).

--- a/src/telemetryDeviceDumper/CMakeLists.txt
+++ b/src/telemetryDeviceDumper/CMakeLists.txt
@@ -20,12 +20,14 @@ if(ENABLE_telemetryDeviceDumper)
     add_definitions(-D_USE_MATH_DEFINES)
   endif()
 
+  find_package(iCubDev REQUIRED)
   target_sources(yarp_telemetryDeviceDumper PRIVATE TelemetryDeviceDumper.cpp
                                                     TelemetryDeviceDumper.h)
-
+                        
   target_link_libraries(yarp_telemetryDeviceDumper PRIVATE YARP::YARP_os
                                                            YARP::YARP_dev
-                                                           robometry::robometry)
+                                                           robometry::robometry
+                                                           ICUB::iCubDev)
   list(APPEND YARP_${YARP_PLUGIN_MASTER}_PRIVATE_DEPS YARP_os
                                                       YARP_dev
                                                       robometry)

--- a/src/telemetryDeviceDumper/CMakeLists.txt
+++ b/src/telemetryDeviceDumper/CMakeLists.txt
@@ -20,7 +20,7 @@ if(ENABLE_telemetryDeviceDumper)
     add_definitions(-D_USE_MATH_DEFINES)
   endif()
 
-  find_package(iCubDev REQUIRED)
+  find_package(iCubDev 2.7.0 REQUIRED)
   target_sources(yarp_telemetryDeviceDumper PRIVATE TelemetryDeviceDumper.cpp
                                                     TelemetryDeviceDumper.h)
                         

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -13,6 +13,7 @@
 using namespace robometry;
 using namespace yarp::os;
 using namespace yarp::dev;
+using namespace iCub;
 
 constexpr double log_thread_default{ 0.010 };
 
@@ -258,7 +259,8 @@ bool TelemetryDeviceDumper::open(yarp::os::Searchable& config) {
     }
 
     // Open RawValuesPublisherClient
-    if (settings.logIRawValuesPublisher) {
+    if (settings.logIRawValuesPublisher) 
+    {
         yarp::os::Property rawValPubClientProp{{"device", Value("rawValuesPublisherClient")},
                                            {"remote", Value(settings.rawValuesPublisherRemoteName)}, //must have the name of the remote port defined in the related nws, i.e. RawValuesPublisherServer
                                            {"local",  Value("/telemetryDeviceDumper" + settings.rawValuesPublisherRemoteName + "/client")}};
@@ -332,15 +334,15 @@ bool TelemetryDeviceDumper::openRemapperControlBoard(yarp::os::Searchable& confi
     }
 
     int axes = 0;
-    if (settings.logControlBoardQuantities){
-        ok = ok && remappedControlBoardInterfaces.encs->getAxes(&axes);
-        if (ok) {
-            this->resizeBuffers(axes);
-        }
-        else {
-            yError() << "telemetryDeviceDumper: open impossible to use the necessary interfaces in remappedControlBoard";
-            return ok;
-        }
+    ok = ok && remappedControlBoardInterfaces.encs->getAxes(&axes);
+    if (ok) 
+    {
+        this->resizeBuffers(axes);
+    }
+    else 
+    {
+        yError() << "telemetryDeviceDumper: open impossible to use the necessary interfaces in remappedControlBoard";
+        return ok;
     }
 
     return true;
@@ -451,9 +453,9 @@ bool TelemetryDeviceDumper::attachAll(const yarp::dev::PolyDriverList& device2at
 
     if (ok && (settings.logIRawValuesPublisher))
     {
-        // COnfiguring channels using metadata from interfaces
+        // Configuring channels using metadata from interfaces
         rawValuesKeyMetadataMap metadata = {}; // I just need to call it once while configuring (I think) 
-        iravap->getMetadataMAP(metadata);
+        iravap->getMetadataMap(metadata);
         for (auto [k, m] : metadata.metadataMap)
         {
             ok = ok && bufferManager.addChannel({ "raw_data_values::"+k, {static_cast<uint16_t>(m.size), 1}, m.rawValueNames });

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -74,7 +74,7 @@ struct TelemetryDeviceDumperSettings {
  * | `logIAmplifierControl`     | bool     | -     | false     | No     | Enable the log of `motors_state::pwm` and `motors_state::currents` (http://yarp.it/git-master/classyarp_1_1dev_1_1IAmplifierControl.html).     |
  * | `logControlBoardQuantities` | bool     | -     | false     | No     | Enable the log of all the quantities that requires the attach to a control board (`logIEncoders`, `logITorqueControl`, `logIMotorEncoders`, `logIControlMode`, `logIInteractionMode`, `logIPidControl`, `logIAmplifierControl`). |
  * | `logILocalization2D` | bool     | -     | false     | No     | Enable the log of `odometry_data` (http://yarp.it/git-master/classyarp_1_1dev_1_1Nav2D_1_1ILocalization2D.html). |
- * | `logIRawValuesPublisher` | bool |   -   | false    | No | Enable the log of raw values |
+ * | `logIRawValuesPublisher` | bool |   -   | false    | No | Enable the log of `raw values` (https://github.com/robotology/icub-main/blob/devel/src/libraries/iCubDev/include/iCub/IRawValuesPublisher.h) |
  * | `saveBufferManagerConfiguration`     | bool     | -    | false     | No     | Enable the save of the configuration of the BufferManager into `path`+ `"bufferConfig"` + `experimentName` + `".json"`     |
  * | `json_file`     | string     | -     | -     | No     | Configure the `robometry::BufferManager`s reading from a json file like [in Example configuration file](#example-configuration-file). Note that this configuration will overwrite the parameter-by-parameter configuration   |
  * | `experimentName`     | string     | -     | -     | Yes     | Prefix of the files that will be saved. The files will be named: `experimentName`+`timestamp`+ `".mat"`.     |
@@ -105,7 +105,7 @@ struct TelemetryDeviceDumperSettings {
  * | `PIDs::torque_error`       | [`yarp::dev::IPidControl::getPidErrors`](http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#aea29e0fdf34f819ac69a3b940556ba28) |
  * | `PIDs::torque_reference`   | [`yarp::dev::IPidControl::getPidReferences`](http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#a29e8f684a15d859229a9ae2902f886da) |
  * | `PIDs::odometry_data   `   | [`yarp::dev::Nav2D::ILocalization2D::getEstimatedOdometry`](http://yarp.it/git-master/classyarp_1_1dev_1_1Nav2D_1_1ILocalization2D.html#a02bff57282777ce7511b671abd4c95f0) |
- * | `raw_data_values`          | [`iCub::debugLibrary::IRawValuesPublisher::getRawDataMap`]
+ * | `raw_data_values`          | [`iCub::debugLibrary::IRawValuesPublisher::getRawDataMap`] (https://github.com/robotology/icub-main/blob/devel/src/libraries/iCubDev/include/iCub/IRawValuesPublisher.h)
  * 
  * @section Example_xml Example of xml
  *


### PR DESCRIPTION
Add to the `telemetryDeviceDumper` a device based on the nwc `rawValuesPublisherClient` thus to save in the MATLAB file generated by this plugin the raw values (and whatever one desired for debugs based on the Interface `iCub::debugLibrary::IRawValuesPublisher`) coming from the boards at the fw level.

**Side Note:** I'll open this PR since I've tested the update done on my bench setup. However, the work, even though at a good point, cannot be considered fully completed. The PR will be kept in draft for now and used for discussion on the updates done and to revise them together

cc: @valegagge @Nicogene @traversaro 