### PR TITLE
Do not require 3.11 nlohmann_json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,16 +71,14 @@ find_package(iCubDev 2.7.0 QUIET)
 
 option(ROBOMETRY_USES_SYSTEM_nlohmann_json OFF)
 
-set(NLOHMANN_JSON_REQUIRED_VERSION 3.11.3)
-# 3.9.2 is unreleased, this option is not working until that version is not released
 if(ROBOMETRY_USES_SYSTEM_nlohmann_json)
-  find_package(nlohmann_json ${NLOHMANN_JSON_REQUIRED_VERSION} REQUIRED)
+  find_package(nlohmann_json 3.10.0 REQUIRED)
 else()
   include(FetchContent)
 
   FetchContent_Declare(json
     GIT_REPOSITORY https://github.com/nlohmann/json.git
-    GIT_TAG v${NLOHMANN_JSON_REQUIRED_VERSION})
+    GIT_TAG v3.11.3
 
   FetchContent_GetProperties(json)
   if(NOT json_POPULATED)


### PR DESCRIPTION
The PR https://github.com/robotology/robometry/pull/194 broke the Ubuntu 22.04 with apt dependencies build of the robotology-superbuild, with error:

~~~
2025-04-01T02:59:13.7266679Z -- Found YARP: /__w/robotology-superbuild/robotology-superbuild/build/install/lib/cmake/YARP (found version "3.11.2+11-20250326.3+git67ec69887")
2025-04-01T02:59:13.7267777Z CMake Error at CMakeLists.txt:77 (find_package):
2025-04-01T02:59:13.7268423Z   Could not find a configuration file for package "nlohmann_json" that is
2025-04-01T02:59:13.7269062Z   compatible with requested version "3.11.3".
2025-04-01T02:59:13.7269384Z 
2025-04-01T02:59:13.7269683Z   The following configuration files were considered but not accepted:
2025-04-01T02:59:13.7270126Z 
2025-04-01T02:59:13.7270452Z     /usr/lib/cmake/nlohmann_json/nlohmann_jsonConfig.cmake, version: 3.10.5
2025-04-01T02:59:13.7271435Z     /lib/cmake/nlohmann_json/nlohmann_jsonConfig.cmake, version: 3.10.5
2025-04-01T02:59:13.7271897Z 
2025-04-01T02:59:13.7271902Z 
~~~

This PR fixes the build, by only requiring nlohmann_json 3.10 when finding it via find_package, while continuing to use nlohmann_json 3.11.3 when used via FetchContent as done in https://github.com/robotology/robometry/pull/194 .