### PR TITLE
Add motor temperature streaming in the `TelemetryDeviceDumper` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,11 @@ The configuration can be saved **to a json file**
 
 ## TelemetryDeviceDumper
 
-The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_devices.html) that has to be launched through the [`yarprobotinterface`](http://yarp.it/git-master/yarprobotinterface.html) for dumping quantities from your robot(e.g. encoders, velocities etc.) in base of what specified in the configuration. It currently needs icub-main version equal or higher than `2.7.0` Specificially this is needed when enabling the parameter `logIRawValuesPublisher`, which is used for dumping any type of raw data values coming from the low level, e.g. raw encoder data. 
+The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_devices.html) that has to be launched through the [`yarprobotinterface`](http://yarp.it/git-master/yarprobotinterface.html) for dumping quantities from your robot(e.g. encoders, velocities etc.) in base of what specified in the configuration. It currently needs icub-main version equal or higher than `2.7.0`. Specificially this is needed when enabling the parameter `logIRawValuesPublisher`, which is used for dumping any type of raw data values coming from the low level, e.g. raw encoder data. Moreover, if you would like to enable the flag `logIMotorTemperatures`, which will allow to collect motor temperatures in `motors_state::temperatures`, you need to use the yarp framework on [this branch](https://github.com/ami-iit/yarp/tree/yarp-3.10.1-motor-temperature), as explained in [this PR](https://github.com/robotology/yarp/pull/3188).
+
+!!! note
+
+Note that since robometry depends on `icub-main`, if you would like to enable the streaming of the motor temperatures, you need to also modify manually [these lines](https://github.com/robotology/icub-main/blob/master/CMakeLists.txt#L21-L22) in the `CMakeLists.txt` file in icub-main otherwise you will get a complain about the yarp minimum version used. Moreover, consider that, since this is still not merged on a stable branch, you might have compilation issues at the moment.
 
 ### Export the env variables
 * Add `${CMAKE_INSTALL_PREFIX}/share/yarp` (where `${CMAKE_INSTALL_PREFIX}` needs to be substituted to the directory that you choose as the `CMAKE_INSTALL_PREFIX`) to your `YARP_DATA_DIRS` environment variable (for more on the `YARP_DATA_DIRS` env variable, see [YARP documentation on data directories](http://www.yarp.it/yarp_data_dirs.html) ).

--- a/README.md
+++ b/README.md
@@ -482,9 +482,8 @@ The configuration can be saved **to a json file**
 
 The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_devices.html) that has to be launched through the [`yarprobotinterface`](http://yarp.it/git-master/yarprobotinterface.html) for dumping quantities from your robot(e.g. encoders, velocities etc.) in base of what specified in the configuration. It currently needs icub-main version equal or higher than `2.7.0`. Specificially this is needed when enabling the parameter `logIRawValuesPublisher`, which is used for dumping any type of raw data values coming from the low level, e.g. raw encoder data. Moreover, if you would like to enable the flag `logIMotorTemperatures`, which will allow to collect motor temperatures in `motors_state::temperatures`, you need to use the yarp framework on [this branch](https://github.com/ami-iit/yarp/tree/yarp-3.10.1-motor-temperature), as explained in [this PR](https://github.com/robotology/yarp/pull/3188).
 
-!!! note
-
-Note that since robometry depends on `icub-main`, if you would like to enable the streaming of the motor temperatures, you need to also modify manually [these lines](https://github.com/robotology/icub-main/blob/master/CMakeLists.txt#L21-L22) in the `CMakeLists.txt` file in icub-main otherwise you will get a complain about the yarp minimum version used. Moreover, consider that, since this is still not merged on a stable branch, you might have compilation issues at the moment.
+>[!NOTE]
+    Note that since robometry depends on `icub-main`, if you would like to enable the streaming of the motor temperatures, you need to also modify manually [these lines](https://github.com/robotology/icub-main/blob/master/CMakeLists.txt#L21-L22) in the `CMakeLists.txt` file in icub-main otherwise you will get a complain about the yarp minimum version used. Moreover, consider that, since this is still not merged on a stable branch, you might have compilation issues at the moment.
 
 ### Export the env variables
 * Add `${CMAKE_INSTALL_PREFIX}/share/yarp` (where `${CMAKE_INSTALL_PREFIX}` needs to be substituted to the directory that you choose as the `CMAKE_INSTALL_PREFIX`) to your `YARP_DATA_DIRS` environment variable (for more on the `YARP_DATA_DIRS` env variable, see [YARP documentation on data directories](http://www.yarp.it/yarp_data_dirs.html) ).

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -73,7 +73,7 @@ struct TelemetryDeviceDumperSettings {
  * | `logIInteractionMode`     | bool     | -     | false     | No     | Enable the log of `joints_state::interaction_mode` (http://yarp.it/git-master/classyarp_1_1dev_1_1IInteractionMode.html.     |
  * | `logIPidControl`     | bool     | -     | false     | No     | Enable the log of `PIDs::position_error`, `PIDs::position_reference`, `PIDs::torque_error`, `PIDs::torque_reference`(http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html).|
  * | `logIAmplifierControl`     | bool     | -     | false     | No     | Enable the log of `motors_state::pwm` and `motors_state::currents` (http://yarp.it/git-master/classyarp_1_1dev_1_1IAmplifierControl.html).     |
- * | `logIMotorTemperatures`     | bool     | -     | false     | No     | Enable the log of `motors_state::temperatures` (http://yarp.it/git-master/classyarp_1_1dev_1_1IMotor.html).     |
+ * | `logIMotorTemperatures`     | bool     | -     | false     | No     | Enable the log of `motors_state::temperatures` available only with [yarp branch](https://github.com/ami-iit/yarp/tree/yarp-3.10.1-motor-temperature) (http://yarp.it/git-master/classyarp_1_1dev_1_1IMotor.html).     |
  * | `logControlBoardQuantities` | bool     | -     | false     | No     | Enable the log of all the quantities that requires the attach to a control board (`logIEncoders`, `logITorqueControl`, `logIMotorEncoders`, `logIControlMode`, `logIInteractionMode`, `logIPidControl`, `logIAmplifierControl`). |
  * | `logILocalization2D` | bool     | -     | false     | No     | Enable the log of `odometry_data` (http://yarp.it/git-master/classyarp_1_1dev_1_1Nav2D_1_1ILocalization2D.html). |
  * | `logIRawValuesPublisher` | bool |   -   | false    | No | Enable the log of `raw values` (https://github.com/robotology/icub-main/blob/devel/src/libraries/iCubDev/include/iCub/IRawValuesPublisher.h) |
@@ -130,7 +130,7 @@ struct TelemetryDeviceDumperSettings {
  *         <param name="logIInteractionMode">true</param>
  *         <param name="logIPidControl">false</param>
  *         <param name="logIAmplifierControl">true</param>
- *         <param name="logIMotorTemperatures">true</param>
+ *         <param name="logIMotorTemperatures">false</param>
  *         <param name="logIRawValuesPublisher">false</param>
  *         <param name="saveBufferManagerConfiguration">true</param>
  *         <param name="experimentName">test_telemetry</param>

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -48,6 +48,7 @@ struct TelemetryDeviceDumperSettings {
     bool logIInteractionMode{ false };
     bool logIPidControl{ false };
     bool logIAmplifierControl{ false };
+    bool logIMotorTemperatures{ false };
     bool logILocalization2D{ false };
     bool logIRawValuesPublisher { false };
     bool useRadians{ false };
@@ -72,6 +73,7 @@ struct TelemetryDeviceDumperSettings {
  * | `logIInteractionMode`     | bool     | -     | false     | No     | Enable the log of `joints_state::interaction_mode` (http://yarp.it/git-master/classyarp_1_1dev_1_1IInteractionMode.html.     |
  * | `logIPidControl`     | bool     | -     | false     | No     | Enable the log of `PIDs::position_error`, `PIDs::position_reference`, `PIDs::torque_error`, `PIDs::torque_reference`(http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html).|
  * | `logIAmplifierControl`     | bool     | -     | false     | No     | Enable the log of `motors_state::pwm` and `motors_state::currents` (http://yarp.it/git-master/classyarp_1_1dev_1_1IAmplifierControl.html).     |
+ * | `logIMotorTemperatures`     | bool     | -     | false     | No     | Enable the log of `motors_state::temperatures` (http://yarp.it/git-master/classyarp_1_1dev_1_1IMotor.html).     |
  * | `logControlBoardQuantities` | bool     | -     | false     | No     | Enable the log of all the quantities that requires the attach to a control board (`logIEncoders`, `logITorqueControl`, `logIMotorEncoders`, `logIControlMode`, `logIInteractionMode`, `logIPidControl`, `logIAmplifierControl`). |
  * | `logILocalization2D` | bool     | -     | false     | No     | Enable the log of `odometry_data` (http://yarp.it/git-master/classyarp_1_1dev_1_1Nav2D_1_1ILocalization2D.html). |
  * | `logIRawValuesPublisher` | bool |   -   | false    | No | Enable the log of `raw values` (https://github.com/robotology/icub-main/blob/devel/src/libraries/iCubDev/include/iCub/IRawValuesPublisher.h) |
@@ -100,6 +102,7 @@ struct TelemetryDeviceDumperSettings {
  * | `motors_state::accelerations` | [`yarp::dev::IMotorEncoders::getMotorEncoderAccelerations`](http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html#a9394d8b5cc4f3d58aeaa07c3fb9a6e6a) |
  * | `motors_state::pwm` | [`yarp::dev::IAmplifierControl::getPWM`](https://yarp.it//git-master/classyarp_1_1dev_1_1IAmplifierControl.html#a71ab30ccf182387bf6552d74f64ccfa5) |
  * | `motors_state::currents` | [`yarp::dev::IAmplifierControl::getCurrents`](https://yarp.it//git-master/classyarp_1_1dev_1_1IAmplifierControl.html#a60ab9c4fdc7f81bd136ad246a9dc57e8) |
+ * | `motors_state::temperatures` | [`yarp::dev::IMotor::getTemperatures`](https://yarp.it//git-master/classyarp_1_1dev_1_1IMotor.html#a60ab9c4fdc7f81bd136ad246a9dc57e8) |
  * | `joints_state::control_mode`       | [`yarp::dev::IControlMode::getControlModes`](http://yarp.it/git-master/classyarp_1_1dev_1_1IControlMode.html#a32f04715873a8099ec40671f65faff8d) |
  * | `joints_state::interaction_mode`   | [`yarp::dev::IInteractionMode::getInteractionModes`](http://yarp.it/git-master/classyarp_1_1dev_1_1IInteractionMode.html#a6055ce20216f479da6c63807a4d11f54) |
  * | `PIDs::position_error`     | [`yarp::dev::IPidControl::getPidErrors`](http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#aea29e0fdf34f819ac69a3b940556ba28) |
@@ -127,6 +130,7 @@ struct TelemetryDeviceDumperSettings {
  *         <param name="logIInteractionMode">true</param>
  *         <param name="logIPidControl">false</param>
  *         <param name="logIAmplifierControl">true</param>
+ *         <param name="logIMotorTemperatures">true</param>
  *         <param name="logIRawValuesPublisher">false</param>
  *         <param name="saveBufferManagerConfiguration">true</param>
  *         <param name="experimentName">test_telemetry</param>
@@ -207,6 +211,7 @@ private:
         yarp::dev::IInteractionMode* imod{ nullptr };
         yarp::dev::ITorqueControl* itrq{ nullptr };
         yarp::dev::IMultipleWrapper* multwrap{ nullptr };
+        yarp::dev::IMotor* imot{ nullptr };
     } remappedControlBoardInterfaces;
 
     yarp::dev::Nav2D::ILocalization2D* iloc{nullptr};
@@ -217,7 +222,7 @@ private:
     std::atomic<bool> correctlyConfigured{ false }, sensorsReadCorrectly{false};
     std::vector<double> jointPos, jointVel, jointAcc, jointPosErr, jointPosRef,
                         jointTrqErr, jointTrqRef, jointPWM, jointCurr, jointTrq,
-                        motorEnc, motorVel, motorAcc, controlModes, interactionModes,
+                        motorEnc, motorVel, motorAcc, motorTemp, controlModes, interactionModes,
                         odometryData;
 
     std::map<std::string, std::vector<std::int32_t>> rawDataValuesMap;


### PR DESCRIPTION
This PR, which is strictly correlated to the modifications done by @GiulioRomualdi in https://github.com/robotology/yarp/pull/3188 and to the information added in [this issue](https://github.com/icub-tech-iit/five/issues/314), allow to add to the `motor_states` in the `MATLAB` files given by the `TelemetryDeviceDumper` the motor temperatures.
As added with a note in the `README.md`, this is still an unstable feature that for working needs manual changes to the compilation of icub-main.
Thus, I suggest to use it with care and mainly by developers or under their supervision for the initial compilation, since it might lead to compilation issues with icub-main. 

cc: @valegagge