### PR TITLE
Added possibility to set a pre save callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 project(robometry LANGUAGES C CXX
-                  VERSION 1.2.8)
+                  VERSION 1.3.0)
 
 include(GNUInstallDirs)
 include(FeatureSummary)

--- a/src/librobometry/include/robometry/BufferManager.h
+++ b/src/librobometry/include/robometry/BufferManager.h
@@ -501,11 +501,23 @@ public:
 
     /**
      * @brief Set the saveCallback function. Thanks to this function you can save additional data
-     * type along with the matfile salve by telemetry
-     * @param[in] saveCallback The saveCallback function
+     * type along with the matfile saved by telemetry. This callback is called after saving the matfile.
+     * The callback receives as input the full path of the matfile just saved and the triggering method.
+     * The callback must return true on success, false otherwise.
+     * @param[in] saveCallback The saveCallback function.
      * @return true on success, false otherwise.
      */
     bool setSaveCallback(std::function<bool(const std::string&, const SaveCallbackSaveMethod& method)> saveCallback);
+
+    /**
+     * @brief Set the preSaveCallback function. Thanks to this function you can decide whether to proceed
+     * with the saving of the matfile or not. This callback is called before saving the matfile.
+     * The callback receives as input the triggering method.
+     * The callback must return true to proceed with the saving, false otherwise.
+     * @param[in] preSaveCallback The preSaveCallback function.
+     * @return true on success, false otherwise.
+     */
+    bool setPreSaveCallback(std::function<bool(const SaveCallbackSaveMethod& method)> preSaveCallback);
 
 
 private:
@@ -547,6 +559,7 @@ private:
 
     std::function<double(void)> m_nowFunction{DefaultClock};
     std::function<bool(const std::string&, const SaveCallbackSaveMethod& method)> m_saveCallback{};
+    std::function<bool(const SaveCallbackSaveMethod& method)> m_preSaveCallback {};
 
     std::thread m_save_thread;
     matioCpp::CellArray m_description_cell_array;

--- a/src/librobometry/src/BufferManager.cpp
+++ b/src/librobometry/src/BufferManager.cpp
@@ -32,10 +32,15 @@ robometry::BufferManager::~BufferManager() {
     }
     if (m_bufferConfig.auto_save) {
         std::string fileName;
-        saveToFile(fileName);
-        if (m_saveCallback)
-        {
-            m_saveCallback(fileName, SaveCallbackSaveMethod::last_call);
+        bool should_save = true;
+        if (m_preSaveCallback) {
+            should_save = m_preSaveCallback(SaveCallbackSaveMethod::last_call);
+        }
+        if (should_save) {
+            saveToFile(fileName);
+            if (m_saveCallback) {
+                m_saveCallback(fileName, SaveCallbackSaveMethod::last_call);
+            }
         }
     }
 }
@@ -223,7 +228,18 @@ bool robometry::BufferManager::setSaveCallback(std::function<bool (const std::st
     return true;
 }
 
-double robometry::BufferManager::DefaultClock() {
+bool robometry::BufferManager::setPreSaveCallback(std::function<bool(const SaveCallbackSaveMethod& method)> preSaveCallback)
+{
+    if (preSaveCallback == nullptr) {
+        std::cout << "Not valid preSaveCallback function." << std::endl;
+        return false;
+    }
+    m_preSaveCallback = preSaveCallback;
+    return true;
+}
+
+double robometry::BufferManager::DefaultClock()
+{
     return std::chrono::duration<double>(std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
@@ -238,11 +254,19 @@ void robometry::BufferManager::periodicSave()
     {
         if (!m_tree->empty()) // if there are channels
         {
-            std::string fileName;
-            saveToFile(fileName, false);
-            if (m_saveCallback)
-            {
-                m_saveCallback(fileName, SaveCallbackSaveMethod::periodic);
+            bool should_save = true;
+            if (m_preSaveCallback) {
+                should_save = m_preSaveCallback(SaveCallbackSaveMethod::periodic);
+            }
+            if (should_save) {
+                std::string fileName;
+                saveToFile(fileName, false);
+                if (m_saveCallback) {
+                    m_saveCallback(fileName, SaveCallbackSaveMethod::periodic);
+                }
+            }
+            else {
+                std::cout << "Pre-save callback prevented the periodic save." << std::endl;
             }
         }
     }

--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -434,12 +434,12 @@ TEST_CASE("Buffer Manager Test")
             bufferConfig.auto_save = true;
 
             REQUIRE(bm.addChannel({ "int_channel", {1}}));
-            bm.setSaveCallback(testCallback);
-            bm.setPreSaveCallback([&called](const robometry::SaveCallbackSaveMethod& /**method*/)
+            REQUIRE(bm.setSaveCallback(testCallback));
+            REQUIRE(bm.setPreSaveCallback([&called](const robometry::SaveCallbackSaveMethod& /**method*/)
             {
                 called = true;
                 return true;
-            });
+            }));
             REQUIRE(bm.configure(bufferConfig));
 
             for (int i = 0; i < 10; i++) {

--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -424,20 +424,30 @@ TEST_CASE("Buffer Manager Test")
 
     SECTION("Callback")
     {
-        robometry::BufferManager bm;
-        robometry::BufferConfig bufferConfig;
-        bufferConfig.n_samples = n_samples;
-        bufferConfig.filename = "buffer_manager_test_callback";
-        bufferConfig.auto_save = true;
+        bool called = false;
 
-        REQUIRE(bm.addChannel({ "int_channel", {1}}));
-        bm.setSaveCallback(testCallback);
-        REQUIRE(bm.configure(bufferConfig));
+        {
+            robometry::BufferManager bm;
+            robometry::BufferConfig bufferConfig;
+            bufferConfig.n_samples = n_samples;
+            bufferConfig.filename = "buffer_manager_test_callback";
+            bufferConfig.auto_save = true;
 
-        for (int i = 0; i < 10; i++) {
-            bm.push_back(i, "int_channel");
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            REQUIRE(bm.addChannel({ "int_channel", {1}}));
+            bm.setSaveCallback(testCallback);
+            bm.setPreSaveCallback([&called](const robometry::SaveCallbackSaveMethod& /**method*/)
+            {
+                called = true;
+                return true;
+            });
+            REQUIRE(bm.configure(bufferConfig));
+
+            for (int i = 0; i < 10; i++) {
+                bm.push_back(i, "int_channel");
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
         }
+        REQUIRE(called);
     }
 
     SECTION("Unit of measure") {


### PR DESCRIPTION
This PR allows the ``BufferManager`` users to know when a mat file is about to be saved. This is to synchronize with other logging tools. Before this PR there was no way to understand when the ``mat`` file was about to be saved when the periodic save is on. More importantly, the [``saveToFile``](https://github.com/robotology/robometry/blob/d6e9745c0e784c294f808b144847a02f2e347a9b/src/librobometry/src/BufferManager.cpp#L158-L202) method does not prevent any concurrent ``push_back`` on the channels, since it does not lock any mutex. This means that if we have a series of channels that we want to be aligned, when pushing to the channels sequentially, some data could end in one file, and other data in the next one. While we are not loosing any data, this could lead to channels of different lengths within a file (I think this is also something that @valegagge and @PasMarra experienced once).

On our side, in the [``BipedalLocomotionFramework::YarpRobotLoggerDevice``](https://github.com/ami-iit/bipedal-locomotion-framework/tree/master/devices/YarpRobotLoggerDevice) we store a set of images periodically in a different thread. We also periodically push to the buffer manager the corresponding frame timestamp. In this case, this callback is even more important, because if the periodic save of the mat file is triggered, we can keep saving frames in the corresponding folder and push the timestamp to the buffer manager, and we don't realize it until the saving is completed. This means that the frames stored while the mat file was being saved will be stored in a folder with the name of the mat file being just saved, **but the corresponding timestamps are saved in the next file**.

This pre save callback allows to notify the buffer manager user that the file is about to be save, and also delaying or cancel its saving if necessary.

cc @GiulioRomualdi @traversaro 